### PR TITLE
Log relayed messages

### DIFF
--- a/src/models/messages.js
+++ b/src/models/messages.js
@@ -4,6 +4,7 @@ const InvalidBodyError = require('five-bells-shared/errors/invalid-body-error')
 const uri = require('../services/uriManager')
 const validator = require('../services/validator')
 const notificationBroadcaster = require('../services/notificationBroadcaster')
+const log = require('../services/log').create('messages')
 
 function * sendMessage (message, requestingUser) {
   const validationResult = validator.create('Message')(message)
@@ -23,6 +24,8 @@ function * sendMessage (message, requestingUser) {
   const senderAccount = message.from
   const senderName = uri.parse(senderAccount, 'account').name.toLowerCase()
   const recipientName = uri.parse(message.to, 'account').name.toLowerCase()
+
+  log.debug('%s -> %s: %o', senderName, recipientName, message.data)
 
   // Only admin can impersonate users.
   if (!requestingUser.is_admin && senderName !== requestingUser.name) {

--- a/src/services/log.js
+++ b/src/services/log.js
@@ -6,7 +6,7 @@ const logStream = require('through2')()
 logStream.pipe(process.stdout)
 
 const create = (namespace) => {
-  return riverpig(namespace, {
+  return riverpig('ledger:' + namespace, {
     stream: logStream
   })
 }


### PR DESCRIPTION
It's currently very difficult to debug anything because things like quote requests, route broadcasts, etc. aren't logged. This patch allows developers to set a `DEBUG=ledger:messages` scope causing the ledger to log all messages it forwards.