### PR TITLE
Execute all transfer updates in SERIALIZABLE isolation level

### DIFF
--- a/src/lib/transferExpiryMonitor.js
+++ b/src/lib/transferExpiryMonitor.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const moment = require('moment')
-const withTransaction = require('./db').withTransaction
+const withSerializableTransaction = require('./db').withSerializableTransaction
 const log = require('../services/log').create('expiry monitor')
 const holds = require('./holds')
 const updateState = require('./updateState')
@@ -30,7 +30,7 @@ class TransferExpiryMonitor {
   * expireTransfer (transferId) {
     const _this = this
 
-    yield withTransaction(function * (transaction) {
+    yield withSerializableTransaction(function * (transaction) {
       const transfer = yield getTransfer(transferId, { transaction })
 
       if (!transfer) {

--- a/src/models/db/adjustments.js
+++ b/src/models/db/adjustments.js
@@ -101,7 +101,7 @@ function upsertAdjustment (persistentAdjustment, options) {
   if (options && options.transaction) {
     return _upsertAdjustment(persistentAdjustment, options.transaction)
   } else {
-    return db.withTransaction((transaction) =>
+    return db.withSerializableTransaction((transaction) =>
       _upsertAdjustment(persistentAdjustment, transaction))
   }
 }

--- a/src/models/db/transfers.js
+++ b/src/models/db/transfers.js
@@ -5,7 +5,7 @@ const _ = require('lodash')
 const client = require('./utils').client
 const db = require('./utils')(TABLE_NAME,
   convertToPersistent, convertFromPersistent)
-const withTransaction = require('../../lib/db').withTransaction
+const withSerializableTransaction = require('../../lib/db').withSerializableTransaction
 const rejectionReasons = require('./rejectionReasons')
 const transferStatuses = require('./transferStatuses')
 const adjustments = require('./adjustments')
@@ -189,6 +189,6 @@ module.exports = {
   upsertTransfer,
   updateTransfer,
   insertTransfers,
-  withTransaction,
+  withSerializableTransaction,
   client
 }


### PR DESCRIPTION
We were already running transfer fulfillments in the SERIALIZABLE isolation level, which ensures consistency for those operations. However, transfer preparations and optimistic transfers were still executed in a lower isolation level. This can result in inconsistent behavior. (I.e. "my money disappeared")

This fix ensures that all operations that touch balances execute in the highest isolation level.

Since database inconsistencies are random, it'd be difficult to add a reliable regression test for this unfortunately.