### PR TITLE
fix: keep sqlite memory db alive

### DIFF
--- a/src/lib/knex.js
+++ b/src/lib/knex.js
@@ -29,7 +29,12 @@ function parseDatabaseType (uri) {
 
 function getKnexConfig () {
   const knexConfig = {
-    sqlite: {client: 'sqlite3', useNullAsDefault: true},
+    sqlite: {
+      client: 'sqlite3',
+      useNullAsDefault: true,
+      // Fix for https://github.com/interledgerjs/five-bells-ledger/issues/354
+      pool: { refreshIdle: false }
+    },
     mysql: {client: 'mysql'},
     postgres: {client: 'pg'}
   }


### PR DESCRIPTION
Change the pool settings for Knex to prevent the database connection
from being cleaned up.

Fixes #354.